### PR TITLE
Remove unnecessary char pointer

### DIFF
--- a/client/client.c
+++ b/client/client.c
@@ -37,8 +37,8 @@ int main(int argc, char *argv[])
   unsigned char peer_pk[BUF_SIZE] = {0, };
   unsigned char plain[BUF_SIZE] = {0, };
   unsigned char ciph[BUF_SIZE] = {0, };
-  unsigned char *msg[NUM_OF_PROBLEMS][BUF_SIZE];
-  unsigned char *sign[NUM_OF_PROBLEMS][BUF_SIZE];
+  unsigned char msg[NUM_OF_PROBLEMS][BUF_SIZE];
+  unsigned char sign[NUM_OF_PROBLEMS][BUF_SIZE];
   unsigned char *sptr;
   int mlen[NUM_OF_PROBLEMS];
   int slen[NUM_OF_PROBLEMS];


### PR DESCRIPTION
This induces unnecesary gcc warnings, such as

client.c:231:35: warning: passing argument 2 of ‘receive_message’ from incompatible pointer type [-Wincompatible-pointer-types]                                                                                                                 ret = receive_message(server, msg[i], BUF_SIZE);                                                                                                                                                                                                                           ^                                                                                                                                                                                                         In file included from client.c:19:0:                                                                                                                                                                                                         ../include/net.h:7:5: note: expected ‘unsigned char *’ but argument is of type ‘unsigned char **’                                                                                                                                         int receive_message(int fd, unsigned char *buf, int max);                                                                                                                                                                                        ^                                                                                                                                                                                                                                       